### PR TITLE
chore: bump version for u-sdk and u-sdk-common to 0.5.1-alpha.1 and 0…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["u-sdk", "u-sdk-common"]
 resolver = "2"
 
 [workspace.dependencies]
-u-sdk-common = { version = "0.2.0", path = "u-sdk-common" }
+u-sdk-common = { version = "0.2.1-alpha.1", path = "u-sdk-common" }
 
 url = "2.5.7"
 percent-encoding = "2.3.2"

--- a/u-sdk-common/Cargo.toml
+++ b/u-sdk-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "u-sdk-common"
-version = "0.2.0"
+version = "0.2.1-alpha.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ian373/u-sdk"

--- a/u-sdk/Cargo.toml
+++ b/u-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "u-sdk"
-version = "0.5.0"
+version = "0.5.1-alpha.1"
 edition = "2024"
 description = "Some useful SDKs"
 keywords = ["aliyun", "oss", "serverchan", "deepseek"]


### PR DESCRIPTION
….2.1-alpha.1